### PR TITLE
Non-modal dialog

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,9 +16,8 @@ def Main():
 		if s.exec():
 			pass
 	else:
-		s = start_main()
-		if s.exec():
-			pass
+		mw.leaderboard = start_main()
+		mw.leaderboard.show()
 		
 
 def setup():


### PR DESCRIPTION
Fixes https://github.com/ThoreBor/Anki_Leaderboard/issues/7
You can do reviews while glaring at the person in the slot above you!
Still requires the user to select Leaderboard→Leaderboard in order to update the display.
Keeps a reference to the dialog, preventing it from being garbage-collected immediately as Main() finishes.
Re-positions the window and switches back to the default tab when re-opened, because setupUi starts from scratch.