### PR TITLE
Change DB access for .24 compat

### DIFF
--- a/Stats.py
+++ b/Stats.py
@@ -46,7 +46,7 @@ def Stats():
 	studied_today = mw.col.findCards('rated:1')
 	total_cards = 0
 	for i in studied_today:
-		value = mw.col.db.execute("SELECT * FROM revlog WHERE cid = (?) ORDER BY id DESC",(i)).fetchall()
+		value = mw.col.db.execute("SELECT * FROM revlog WHERE cid = (?) ORDER BY id DESC",(i))
 		for i in value:
 			id_time = i[0]
 			id_time = time.strftime('%Y-%m-%d', time.localtime(int(id_time)/1000.0))
@@ -57,7 +57,7 @@ def Stats():
 	
 	time_today = 0
 	for i in studied_today:
-		value = mw.col.db.execute("SELECT * FROM revlog WHERE cid = (?) ORDER BY id DESC",(i)).fetchall()
+		value = mw.col.db.execute("SELECT * FROM revlog WHERE cid = (?) ORDER BY id DESC",(i))
 		for i in value:
 			id_time = i[0]
 			id_time = time.strftime('%Y-%m-%d', time.localtime(int(id_time)/1000.0))


### PR DESCRIPTION
Tested with Anki Version 2.1.24 (6ecf2ffa) on Debian bullseye.
Not sure if this works with older versions of Anki as well, but since AnkiWeb can host version-aware releases, backwards compat isn't required.
Fixes #33