### PR TITLE
Open the custom config dialog from the add-on manager

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,3 +50,5 @@ add_menu('Leaderboard',"Leaderboard", Main, 'Shift+L')
 add_menu('Leaderboard',"Make a feature request or report a bug", github)
 add_menu('Leaderboard',"Config", setup)
 add_menu('Leaderboard',"About", about)
+
+mw.addonManager.setConfigAction(__name__, setup)


### PR DESCRIPTION
Open the add-on's own config dialog when clicking on the "Config" button in the add-on manager.