### PR TITLE
Use variable for field background color

### DIFF
--- a/Setup.py
+++ b/Setup.py
@@ -184,7 +184,7 @@ class start_setup(QDialog):
 				self.dialog.account_button.setEnabled(True)
 				if pwd == pwd_repeat and pwd:
 					self.dialog.account_button.setEnabled(True)
-					self.dialog.account_pwd_repeat.setStyleSheet("background-color: #ffffff")
+					self.dialog.account_pwd_repeat.setStyleSheet("background-color: var(--window-bg)")
 				if pwd != pwd_repeat and pwd:
 					self.dialog.account_button.setEnabled(False)
 					self.dialog.account_pwd_repeat.setStyleSheet("background-color: #ff4242")


### PR DESCRIPTION
White background is not suited for night mode.
Tested only with Anki 2.1.35 and only in night mode.