### PR TITLE
Update for PyQt6

### DIFF
--- a/Achievement.py
+++ b/Achievement.py
@@ -7,7 +7,7 @@ from .forms import achievement
 class start_achievement(QDialog):
 	def __init__(self, value, parent=None):
 		self.parent = parent
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = achievement.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.value = value

--- a/Leaderboard.py
+++ b/Leaderboard.py
@@ -35,7 +35,7 @@ class start_main(QDialog):
 		self.season_end = season_end
 		self.current_season = current_season
 		self.groups_lb = []
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = Leaderboard.Ui_dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()
@@ -87,12 +87,12 @@ class start_main(QDialog):
 		self.dialog.Country_Leaderboard, self.dialog.Custom_Leaderboard, self.dialog.League]
 		for l in lb_list:
 			header = l.horizontalHeader()   
-			header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
-			header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
-			header.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
-			header.setSectionResizeMode(3, QtWidgets.QHeaderView.Stretch)
-			header.setSectionResizeMode(4, QtWidgets.QHeaderView.Stretch)
-			header.setSectionResizeMode(5, QtWidgets.QHeaderView.Stretch)
+			header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
+			header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
+			header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeMode.Stretch)
+			header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
+			header.setSectionResizeMode(4, QtWidgets.QHeaderView.ResizeMode.Stretch)
+			header.setSectionResizeMode(5, QtWidgets.QHeaderView.ResizeMode.Stretch)
 		
 		self.load_leaderboard()
 
@@ -104,29 +104,29 @@ class start_main(QDialog):
 		tab.setItem(rowPosition , 0, QtWidgets.QTableWidgetItem(str(username)))
 
 		item = QtWidgets.QTableWidgetItem()
-		item.setData(QtCore.Qt.DisplayRole, int(cards))
+		item.setData(QtCore.Qt.ItemDataRole.DisplayRole, int(cards))
 		tab.setItem(rowPosition, 1, item)
-		item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+		item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 		item = QtWidgets.QTableWidgetItem()
-		item.setData(QtCore.Qt.DisplayRole, float(time))
+		item.setData(QtCore.Qt.ItemDataRole.DisplayRole, float(time))
 		tab.setItem(rowPosition, 2, item)
-		item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+		item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 		item = QtWidgets.QTableWidgetItem()
-		item.setData(QtCore.Qt.DisplayRole, int(streak))
+		item.setData(QtCore.Qt.ItemDataRole.DisplayRole, int(streak))
 		tab.setItem(rowPosition, 3, item)
-		item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+		item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 		item = QtWidgets.QTableWidgetItem()
-		item.setData(QtCore.Qt.DisplayRole, month)
+		item.setData(QtCore.Qt.ItemDataRole.DisplayRole, month)
 		tab.setItem(rowPosition, 4, item)
-		item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+		item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 		item = QtWidgets.QTableWidgetItem()
-		item.setData(QtCore.Qt.DisplayRole, retention)
+		item.setData(QtCore.Qt.ItemDataRole.DisplayRole, retention)
 		tab.setItem(rowPosition, 5, item)
-		item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+		item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 	def switchGroup(self):
 		self.dialog.Custom_Leaderboard.setSortingEnabled(False)

--- a/League.py
+++ b/League.py
@@ -57,15 +57,15 @@ def load_league(self, colors):
 
 			self.dialog.League.setItem(rowPosition, 0, QtWidgets.QTableWidgetItem(str(username)))
 			self.dialog.League.setItem(rowPosition, 1, QtWidgets.QTableWidgetItem(str(xp)))
-			self.dialog.League.item(rowPosition, 1).setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+			self.dialog.League.item(rowPosition, 1).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 			self.dialog.League.setItem(rowPosition, 2, QtWidgets.QTableWidgetItem(str(reviews)))
-			self.dialog.League.item(rowPosition, 2).setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+			self.dialog.League.item(rowPosition, 2).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 			self.dialog.League.setItem(rowPosition, 3, QtWidgets.QTableWidgetItem(str(time_spend)))
-			self.dialog.League.item(rowPosition, 3).setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+			self.dialog.League.item(rowPosition, 3).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 			self.dialog.League.setItem(rowPosition, 4, QtWidgets.QTableWidgetItem(str(retention)))
-			self.dialog.League.item(rowPosition, 4).setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+			self.dialog.League.item(rowPosition, 4).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 			self.dialog.League.setItem(rowPosition, 5, QtWidgets.QTableWidgetItem(str(days_learned)))
-			self.dialog.League.item(rowPosition, 5).setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+			self.dialog.League.item(rowPosition, 5).setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 			if username.split(" |")[0] in config['friends']:
 				for j in range(self.dialog.League.columnCount()):
@@ -118,7 +118,7 @@ def load_league(self, colors):
 		if item == config['username']:
 			userposition = self.dialog.League.item(i, 0)
 			self.dialog.League.selectRow(i)
-			self.dialog.League.scrollToItem(userposition, QAbstractItemView.PositionAtCenter)
+			self.dialog.League.scrollToItem(userposition, QAbstractItemView.ScrollHint.PositionAtCenter)
 			self.dialog.League.clearSelection()
 	
 	write_config("medal_users", medal_users)

--- a/banUser.py
+++ b/banUser.py
@@ -9,7 +9,7 @@ from .api_connect import connectToAPI
 class start_banUser(QDialog):
 	def __init__(self, user_clicked, parent=None):
 		self.parent = parent
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = banUser.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.user_clicked = user_clicked
@@ -26,5 +26,4 @@ class start_banUser(QDialog):
 		x = connectToAPI("banUser/", False, data, "Done!", "banUser")
 		if x.text == "Done!":
 			tooltip(f"{toBan} is now banned from {config['current_group']}")
-		
 		

--- a/config.py
+++ b/config.py
@@ -31,7 +31,7 @@ class start_config(QDialog):
 		self.parent = parent
 		self.season_start = season_start
 		self.season_end = season_end
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = config.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()

--- a/reportUser.py
+++ b/reportUser.py
@@ -9,7 +9,7 @@ class start_report(QDialog):
 	def __init__(self, user_clicked, parent=None):
 		self.parent = parent
 		self.user_clicked = user_clicked
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = report.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()

--- a/resetPassword.py
+++ b/resetPassword.py
@@ -8,7 +8,7 @@ from .api_connect import connectToAPI
 class start_resetPassword(QDialog):
 	def __init__(self, parent=None):
 		self.parent = parent
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = reset_password.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()
@@ -27,4 +27,3 @@ class start_resetPassword(QDialog):
 			showWarning("Something went wrong")
 		else:
 			tooltip("Email sent")
-		

--- a/tools/build_ui.sh
+++ b/tools/build_ui.sh
@@ -2,6 +2,39 @@
 
 set -e
 
+# Argument parsing
+# https://stackoverflow.com/a/14203146
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+        -b|--build-tool)
+            TOOL="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [ ! "${TOOL}" ]; then
+    TOOL="pyuic5"
+elif [[ ! "${TOOL}" = "pyuic5" && ! "${TOOL}" = "pyuic6" ]]; then
+    echo "Only 'pyuic5' or 'pyuic6' are permitted for -b|--build-tool. Defaults to 'pyuic5' when omitted."
+    echo "Exiting..."
+    exit 1
+fi
+
+if [ "${TOOL}" = "pyuic5" ]; then
+    OPTIONS="--from-imports"
+fi
+
 if [ ! -d "designer" ]
 then
     echo "Please run this from the project root"
@@ -17,7 +50,7 @@ do
     py="forms/${base}.py"
     if [ $i -nt $py ]; then
         echo " * "$py
-        pyuic5 --from-imports $i -o $py
+        ${TOOL} ${OPTIONS} $i -o $py
     fi
 done
 

--- a/userInfo.py
+++ b/userInfo.py
@@ -16,7 +16,7 @@ class start_user_info(QDialog):
 		self.parent = parent
 		self.user_clicked = user_clicked.split(" |")[0]
 		self.enabled = enabled
-		QDialog.__init__(self, parent, Qt.Window)
+		QDialog.__init__(self, parent, Qt.WindowType.Window)
 		self.dialog = user_info.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()
@@ -35,10 +35,10 @@ class start_user_info(QDialog):
 			pass
 
 		header = self.dialog.history.horizontalHeader()   
-		header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
-		header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
-		header.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
-		header.setSectionResizeMode(3, QtWidgets.QHeaderView.Stretch)
+		header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+		header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
+		header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeMode.Stretch)
+		header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
 
 		if data[0] == "Country":
 			data[0] = None
@@ -61,19 +61,19 @@ class start_user_info(QDialog):
 				self.dialog.history.setItem(rowPosition , 3, QtWidgets.QTableWidgetItem(str(i)))
 
 				item = QtWidgets.QTableWidgetItem()
-				item.setData(QtCore.Qt.DisplayRole, int(results["seasons"][index]))
+				item.setData(QtCore.Qt.ItemDataRole.DisplayRole, int(results["seasons"][index]))
 				self.dialog.history.setItem(rowPosition, 0, item)
-				item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+				item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 				item = QtWidgets.QTableWidgetItem()
-				item.setData(QtCore.Qt.DisplayRole, int(results["xp"][index]))
+				item.setData(QtCore.Qt.ItemDataRole.DisplayRole, int(results["xp"][index]))
 				self.dialog.history.setItem(rowPosition, 2, item)
-				item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+				item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 				item = QtWidgets.QTableWidgetItem()
-				item.setData(QtCore.Qt.DisplayRole, int(results["rank"][index]))
+				item.setData(QtCore.Qt.ItemDataRole.DisplayRole, int(results["rank"][index]))
 				self.dialog.history.setItem(rowPosition, 1, item)
-				item.setTextAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+				item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight|QtCore.Qt.AlignmentFlag.AlignVCenter)
 
 				index += 1
 		for i in data[1]:
@@ -84,7 +84,7 @@ class start_user_info(QDialog):
 		self.dialog.addFriend.clicked.connect(self.addFriend)
 		self.dialog.banUser.clicked.connect(self.banUser)
 		self.dialog.reportUser.clicked.connect(self.reportUser)
-		self.dialog.history.sortItems(0, QtCore.Qt.DescendingOrder)
+		self.dialog.history.sortItems(0, QtCore.Qt.SortOrder.DescendingOrder)
 
 	def hideUser(self):
 		config = mw.addonManager.getConfig(__name__)


### PR DESCRIPTION
Starting from version 2.1.50, Anki uses PyQt6.
Compatibility shims are provided, so there is no rush to make the add-on code compatible with PyQt6.

I have updated all the deprecated code I could find so far.
Also, designer files should be built with pyuic6 (again, pyuic5 will work as long as compatibility shims are in place), which I made possible by changing the UI build script. It still uses pyuic5 by default.

I did not get the window icons to work.

Tested with Anki Version ⁨2.1.50 (2df3698e8)⁩
Python 3.9.7 Qt 6.2.2 PyQt 6.2.2
on Debian bookworm